### PR TITLE
Update GitHub statuses from Jenkins build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Features
 - Requeue jobs on queue loss.
 - Retry on network failure.
 - Nice with humans: wait for queue to be empty before queuing new PR jobs.
+- Update GitHub commit status from Jenkins status.
 
 
 Skipping jobs

--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -161,8 +161,11 @@ class BuilderExtension(Extension):
                 'state': 'success',
             })
         else:
+            current_status = self.bot.pr.get_status_for(context)
+            already_queued = 'Queued' == current_status.get('description')
+            queued = self.bot.queue_empty or already_queued
             new_status.update({
-                'description': 'Queued' if self.bot.queue_empty else 'Backed',
+                'description': 'Queued' if queued else 'Backed',
                 'state': 'pending',
             })
         return new_status

--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -1,31 +1,187 @@
+import collections
 import copy
+import inspect
 import logging
 import pkg_resources
 import re
 import socket
 
+from .settings import SETTINGS
+
 
 logger = logging.getLogger(__name__)
-DISTRIBUTION = pkg_resources.get_distribution('jenkins_ghp')
-HELP = """\
+
+
+class Bot(object):
+    DEFAULTS = {
+        'help-mentions': set(),
+        'skip': (),
+        'rebuild-failed': None,
+    }
+
+    def __init__(self, queue_empty=True):
+        self.queue_empty = queue_empty
+        self.extensions = {}
+        for ep in pkg_resources.iter_entry_points(__name__ + '.extensions'):
+            cls = ep.load()
+            self.extensions[ep.name] = ext = cls(ep.name, self)
+            SETTINGS.load(ext.SETTINGS)
+            logger.info("Loaded extension %s", ep.name)
+
+    def workon(self, pr):
+        logger.info("Working on %s", pr)
+        self.pr = pr
+        self.settings = copy.deepcopy(self.DEFAULTS)
+        return self
+
+    def run(self, pr):
+        self.workon(pr)
+
+        for ext in self.extensions.values():
+            ext.begin()
+
+        self.process_instructions()
+        logger.debug("Bot settings: %r", self.settings)
+
+        for ext in self.extensions.values():
+            ext.end()
+
+    def process_instructions(self):
+        process = True
+        for date, author, data in self.pr.list_instructions():
+            if isinstance(data, str):
+                data = {data: None}
+            if isinstance(data, list):
+                data = collections.OrderedDict(zip(data, [None]*len(data)))
+
+            for name, args in data.items():
+                name = name.lower()
+                instruction = Instruction(name, args, author, date)
+                if not process:
+                    process = 'process' == instruction
+                    continue
+                elif instruction == 'ignore':
+                    process = False
+                else:
+                    for ext in self.extensions.values():
+                        ext.process_instruction(instruction)
+
+
+class Instruction(object):
+    def __init__(self, name, args, author, date):
+        self.name = name
+        self.args = args
+        self.author = author
+        self.date = date
+
+    def __str__(self):
+        return self.name
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return str(self) == other
+        else:
+            return super(Instruction, self).__eq__(other)
+
+
+class Extension(object):
+    DEFAULTS = {}
+    SETTINGS = {}
+
+    def __init__(self, name, bot):
+        self.name = name
+        self.bot = bot
+
+    def begin(self):
+        self.bot.settings.update(copy.deepcopy(self.DEFAULTS))
+
+    def process_instruction(self, instruction):
+        pass
+
+    def end(self):
+        pass
+
+
+class BuilderExtension(Extension):
+    """
+    # Skipping jobs
+    jenkins: skip
+    jenkins: {skip: '(?!except-this)'}
+    jenkins:
+    skip: ['this.*', 'that']
+
+    # Requeue past failed jobs
+    jenkins: rebuild
+    """
+
+    DEFAULTS = {
+        'skip': [],
+        'rebuild-failed': None,
+    }
+    SKIP_ALL = ('.*',)
+
+    def process_instruction(self, instruction):
+        if instruction == 'skip':
+            patterns = instruction.args
+            if isinstance(patterns, str):
+                patterns = [patterns]
+            self.bot.settings['skip'] = patterns or self.SKIP_ALL
+        elif instruction == 'rebuild':
+            self.bot.settings['rebuild-failed'] = instruction.date
+
+    def end(self):
+        for job in self.bot.pr.project.jobs:
+            not_built = self.bot.pr.filter_not_built_contexts(
+                job.list_contexts(),
+                rebuild_failed=self.bot.settings['rebuild-failed']
+            )
+            if not_built and self.bot.queue_empty:
+                job.build(
+                    self.bot.pr, [c for c in not_built if not self.skip(c)]
+                )
+
+            for context in not_built:
+                self.bot.pr.update_statuses(
+                    **self.status_for_new_context(context)
+                )
+
+    def skip(self, context):
+        for pattern in self.bot.settings['skip']:
+            try:
+                if re.match(pattern, context):
+                    return True
+            except re.error as e:
+                logger.warn("Bad pattern for skip: %s", e)
+
+    def status_for_new_context(self, context):
+        new_status = {'context': context}
+        if self.skip(context):
+            new_status.update({
+                'description': 'Skipped',
+                'state': 'success',
+            })
+        else:
+            new_status.update({
+                'description': 'Queued' if self.bot.queue_empty else 'Backed',
+                'state': 'pending',
+            })
+        return new_status
+
+
+class HelpExtension(Extension):
+    DEFAULTS = {
+        'help-mentions': set(),
+    }
+    DISTRIBUTION = pkg_resources.get_distribution('jenkins_ghp')
+    HELP = """\
 <!--
 jenkins: ignore
 -->
 
-%(mentions)s, this is what I understand:
+%(mentions)s: this is what I understand:
 
 ```yaml
-# Skipping jobs
-jenkins: skip
-jenkins: {skip: '(?!except-this)'}
-jenkins:
-  skip: ['this.*', 'that']
-
-# Requeue past failed jobs
-jenkins: rebuild
-
-# Ask for manual
-jenkins: help|man
+%(help)s
 ```
 
 You can mix instructions. Multiline instructions **must** be in code block.
@@ -37,107 +193,39 @@ You can mix instructions. Multiline instructions **must** be in code block.
 jenkins: [process, help-reset]
 
 Running %(software)s==%(version)s on %(host)s
+Extensions: %(extensions)s
 -->
 """
 
+    def process_instruction(self, instruction):
+        if instruction.name in ('help', 'man'):
+            self.bot.settings['help-mentions'].add(instruction.author)
+        elif instruction == 'help-reset':
+            self.bot.settings['help-mentions'] = set()
 
-class Bot(object):
-    DEFAULTS = {
-        'actions': set(),
-        'help-mentions': set(),
-        'skip': (),
-        'rebuild-failed': None,
-    }
-    SKIP_ALL = ('.*',)
-
-    def __init__(self, queue_empty=True):
-        self.queue_empty = queue_empty
-        self.settings = {}
-
-    def load_instructions(self, pr):
-        self.settings = copy.deepcopy(self.DEFAULTS)
-        self.settings['actions'].add(self.build)
-        process = True
-        for date, author, instructions in pr.list_instructions():
-            if isinstance(instructions, str):
-                instructions = [instructions]
-            for instruction in instructions:
-                instruction = instruction.lower()
-                if not process:
-                    process = 'process' == instruction
-                    continue
-                if instruction == 'skip':
-                    patterns = None
-                    if isinstance(instructions, dict):
-                        patterns = instructions['skip']
-                        if isinstance(patterns, str):
-                            patterns = [patterns]
-                    self.settings['skip'] = patterns or self.SKIP_ALL
-                elif instruction == 'rebuild':
-                    self.settings['rebuild-failed'] = date
-                elif instruction in ('help', 'man'):
-                    self.settings['actions'].add(self.help_)
-                    self.settings['help-mentions'].add(author)
-                elif instruction == 'help-reset':
-                    try:
-                        self.settings['actions'].remove(self.help_)
-                    except KeyError:
-                        pass
-                    self.settings['help-mentions'] = set()
-                elif instruction == 'ignore':
-                    process = False
-                else:
-                    logger.warn("I don't understand %r", instruction)
-
-        logger.debug("Bot settings: %r", self.settings)
-
-    def run(self, pr):
-        logger.info("Working on %s", pr)
-        self.load_instructions(pr)
-        for action in self.settings['actions']:
-            action(pr)
-
-    def status_for_new_context(self, context):
-        new_status = {'context': context}
-        if self.skip(context):
-            new_status.update({
-                'description': 'Skipped',
-                'state': 'success',
-            })
-        else:
-            new_status.update({
-                'description': 'Queued' if self.queue_empty else 'Backed',
-                'state': 'pending',
-            })
-        return new_status
-
-    def build(self, pr):
-        for job in pr.project.jobs:
-            not_built = pr.filter_not_built_contexts(
-                job.list_contexts(),
-                rebuild_failed=self.settings['rebuild-failed']
-            )
-            if not_built and self.queue_empty:
-                job.build(pr, [c for c in not_built if not self.skip(c)])
-
-            for context in not_built:
-                pr.update_statuses(**self.status_for_new_context(context))
-
-    def help_(self, pr):
-        pr.comment(HELP % dict(
+    def generate_comment(self):
+        docs = []
+        for ext in self.bot.extensions.values():
+            doc = ext.__class__.__doc__
+            if not doc:
+                continue
+            docs.append(inspect.cleandoc(doc))
+        help_ = '\n\n'.join(docs)
+        return self.HELP % dict(
+            extensions=','.join(sorted(self.bot.extensions.keys())),
+            help=help_,
             host=socket.getfqdn(),
             me='Jenkins GitHub Builder',
-            mentions=','.join([
-                '@' + m for m in self.settings['help-mentions']
-            ]),
-            software=DISTRIBUTION.project_name,
-            version=DISTRIBUTION.version,
-        ))
+            mentions=', '.join(sorted([
+                '@' + m for m in self.bot.settings['help-mentions']
+            ])),
+            software=self.DISTRIBUTION.project_name,
+            version=self.DISTRIBUTION.version,
+        )
 
-    def skip(self, context):
-        for pattern in self.settings['skip']:
-            try:
-                if re.match(pattern, context):
-                    return True
-            except re.error as e:
-                logger.warn("Bad pattern for skip: %s", e)
+    def answer_help(self):
+        self.bot.pr.comment(self.generate_comment())
+
+    def end(self):
+        if self.bot.settings['help-mentions']:
+            self.answer_help()

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import re
 
@@ -7,7 +6,7 @@ import requests
 import yaml
 
 from .settings import SETTINGS
-from .utils import match, retry
+from .utils import match, parse_datetime, retry
 
 
 logger = logging.getLogger(__name__)
@@ -62,9 +61,7 @@ class PullRequest(object):
             state = status.get('state')
             # Skip failed job, unless rebuild asked and old
             if state in {'error', 'failure'}:
-                failure_date = datetime.datetime.strptime(
-                    status['updated_at'], '%Y-%m-%dT%H:%M:%SZ'
-                )
+                failure_date = parse_datetime(status['updated_at'])
                 if rebuild_failed and failure_date > rebuild_failed:
                     continue
             # Skip `Backed`, `New` and `Queued` jobs
@@ -149,21 +146,18 @@ class PullRequest(object):
                     continue
 
                 yield (
-                    datetime.datetime.strptime(
-                        comment['updated_at'],
-                        '%Y-%m-%dT%H:%M:%SZ'
-                    ),
+                    parse_datetime(comment['updated_at']),
                     comment['user']['login'],
                     instruction['jenkins'],
                 )
 
     @retry()
-    def update_statuses(self, context, state, description, url=None):
+    def update_statuses(self, context, state, description, target_url=None):
         current_statuses = self.get_statuses()
 
         new_status = dict(
             context=context, description=description,
-            state=state, target_url=url,
+            state=state, target_url=target_url,
         )
 
         if context in current_statuses:

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -69,6 +69,8 @@ class PullRequest(object):
                     continue
             # Skip `Backed`, `New` and `Queued` jobs
             elif state == 'pending':
+                # Jenkins deduplicate jobs in the queue. So it's safe to keep
+                # triggering the job in case the queue was flushed.
                 if status['description'] not in {'Backed', 'New', 'Queued'}:
                     continue
             # Skip other known states

--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -7,6 +7,10 @@ logger = logging.getLogger(__name__)
 
 class EnvironmentSettings(object):
     def __init__(self, defaults):
+        self.load(defaults)
+        logger.debug("Environment loaded.")
+
+    def load(self, defaults):
         for k, v in sorted(defaults.items()):
             v = os.environ.get(k, v)
             try:
@@ -15,7 +19,6 @@ class EnvironmentSettings(object):
                 pass
             setattr(self, k, v)
             logger.debug("%s=%r", k, v)
-        logger.debug("Environment loaded.")
 
 
 SETTINGS = EnvironmentSettings(defaults={

--- a/jenkins_ghp/utils.py
+++ b/jenkins_ghp/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import fnmatch
 import functools
 import logging
@@ -30,3 +31,9 @@ retry = functools.partial(
 
 def match(item, patterns):
     return not patterns or [p for p in patterns if fnmatch.fnmatch(item, p)]
+
+
+def parse_datetime(formatted):
+    return datetime.datetime.strptime(
+        formatted, '%Y-%m-%dT%H:%M:%SZ'
+    )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
     version='0.1',
     entry_points={
         'console_scripts': ['jenkins-ghp=jenkins_ghp.script:entrypoint'],
+        'jenkins_ghp.bot.extensions': [
+            'builder = jenkins_ghp.bot:BuilderExtension',
+            'help = jenkins_ghp.bot:HelpExtension',
+        ],
     },
     extras_require={
         'release': ['wheel', 'zest.releaser'],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'console_scripts': ['jenkins-ghp=jenkins_ghp.script:entrypoint'],
         'jenkins_ghp.bot.extensions': [
             'builder = jenkins_ghp.bot:BuilderExtension',
+            'fix = jenkins_ghp.bot:FixStatusExtension',
             'help = jenkins_ghp.bot:HelpExtension',
         ],
     },

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,33 +2,33 @@ from mock import Mock
 
 
 def test_compute_skip_null():
-    from jenkins_ghp.bot import Bot
+    from jenkins_ghp.bot import Bot, BuilderExtension
 
     pr = Mock()
     pr.list_instructions.return_value = [
         (0, 0, {'skip': None}),
     ]
 
-    bot = Bot()
-    bot.load_instructions(pr)
-    assert bot.settings['skip'] == bot.SKIP_ALL
+    bot = Bot().workon(pr)
+    bot.process_instructions()
+    assert bot.settings['skip'] == BuilderExtension.SKIP_ALL
 
 
 def test_compute_skip():
-    from jenkins_ghp.bot import Bot
+    from jenkins_ghp.bot import Bot, BuilderExtension
 
     pr = Mock()
-    bot = Bot()
+    bot = Bot().workon(pr)
 
     pr.list_instructions.return_value = [(0, 0, 'skip')]
-    bot.load_instructions(pr)
-    assert bot.settings['skip'] == bot.SKIP_ALL
+    bot.process_instructions()
+    assert bot.settings['skip'] == BuilderExtension.SKIP_ALL
 
     pr.list_instructions.return_value = [
         (0, 0, {'skip': None}),
         (0, 0, {'skip': ['this']}),
     ]
-    bot.load_instructions(pr)
+    bot.process_instructions()
     assert bot.settings['skip'] == ['this']
 
 
@@ -36,10 +36,10 @@ def test_compute_rebuild():
     from jenkins_ghp.bot import Bot
 
     pr = Mock()
-    bot = Bot()
+    bot = Bot().workon(pr)
 
     pr.list_instructions.return_value = [('DATE', 0, 'rebuild')]
-    bot.load_instructions(pr)
+    bot.process_instructions()
     assert bot.settings['rebuild-failed'] == 'DATE'
 
 
@@ -47,31 +47,30 @@ def test_compute_help():
     from jenkins_ghp.bot import Bot
 
     pr = Mock()
-    bot = Bot()
+    bot = Bot().workon(pr)
 
     pr.list_instructions.return_value = [(0, 'asker', 'help')]
-    bot.load_instructions(pr)
-    assert bot.help_ in bot.settings['actions']
+    bot.process_instructions()
     assert 'asker' in bot.settings['help-mentions']
 
     pr.list_instructions.return_value = [
         (0, 'asker1', 'help'),
         (0, 'bot', 'help-reset'),
     ]
-    bot.load_instructions(pr)
-    assert bot.help_ not in bot.settings['actions']
+    bot.process_instructions()
     assert not bot.settings['help-mentions']
 
     pr.list_instructions.return_value = [
         (0, 'asker1', 'help'),
         (0, 'asker2', 'help'),
     ]
-    bot.load_instructions(pr)
-    assert bot.help_ in bot.settings['actions']
+    bot.process_instructions()
     assert 'asker1' in bot.settings['help-mentions']
     assert 'asker2' in bot.settings['help-mentions']
 
-    bot.help_(pr)
+    comment = bot.extensions['help'].generate_comment()
+    assert '@asker1' in comment
+    assert '@asker2' in comment
 
 
 def test_skip_re():
@@ -82,10 +81,10 @@ def test_skip_re():
         (None, None, {'skip': ['toto.*', '(?!notthis)']}),
     ]
 
-    bot = Bot()
-    bot.load_instructions(pr)
-    assert bot.skip('toto-doc')
-    assert not bot.skip('notthis')
+    bot = Bot().workon(pr)
+    bot.process_instructions()
+    assert bot.extensions['builder'].skip('toto-doc')
+    assert not bot.extensions['builder'].skip('notthis')
 
 
 def test_skip_re_wrong():
@@ -96,6 +95,6 @@ def test_skip_re_wrong():
         (None, None, {'skip': ['*toto)']}),
     ]
 
-    bot = Bot()
-    bot.load_instructions(pr)
-    assert not bot.skip('toto')
+    bot = Bot().workon(pr)
+    bot.process_instructions()
+    assert not bot.extensions['builder'].skip('toto')

--- a/tests/test_fix_statuses.py
+++ b/tests/test_fix_statuses.py
@@ -1,0 +1,7 @@
+def test_duration_format():
+    from jenkins_ghp.bot import format_duration
+
+    assert '4.2 sec' == format_duration(4200)
+    assert '23 sec' == format_duration(23000)
+    assert '5 min 4.2 sec' == format_duration(304200)
+    assert '2 h 5 min 4.2 sec' == format_duration(7504200)


### PR DESCRIPTION
Ça, c'est une killer feature. Plus besoin de vérifier sur jenkins si un job est toujours en cour :-D

Plus généralement, ça couvre les cas suivants :

 - jenkins n'a pas marqué le job comme terminé (erreur réseau, mauvaise configuration)
 - jenkins marque un job abandonné comme en échec, alors qu'on veut en fait le sauter.

Proposition:

 - Le succès ou l'échec d'un build est remonté dans github
 - Les jobs en cours sont vérifiés toutes les 5 minutes (paramétrable)
 - Un build avorté est marqué pour être relancé. Si on veut vraiment l'annuler, on le skip comme les autres.
 - Les builds vraiment en échecs ne sont testé qu'une fois.

Autre fonctionnalité ultime : extensibilité du bot via des entry points :-)