### PR TITLE
Execute flake8 in python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,6 @@ commands =
     py.test -vvvv --strict --showlocals --junit-xml={env:CIRCLE_TEST_REPORTS:.}/junit.xml tests/
 
 [testenv:lint]
+basepython = python3.4
 deps = flake8
 commands = flake8 --verbose jenkins_ghp/ tests/


### PR DESCRIPTION
This fixes SyntaxError on `yield from`:

    jenkins_ghp/main.py:24:31: E901 SyntaxError: invalid syntax