### PR TITLE
Don't install dist.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py{34,35},lint,release
-usedevelop = True
 
 [testenv]
+usedevelop = true
 commands =
     pip --disable-pip-version-check install -e .[test]
     py.test -vvvv --strict --showlocals --junit-xml={env:CIRCLE_TEST_REPORTS:.}/junit.xml tests/


### PR DESCRIPTION
Replaces::

    py34 inst-nodeps /home/jpic/env/src/ghp/.tox/dist/jenkins-ghp-1.3.dev0.zip

With::

    py34 develop-inst-nodeps: /home/jpic/env/src/ghp

Note that ``pip install -e .[test]`` is still required for ``[test]``
extra requirements. This patch just prevents the dist to be built and
installed.