### PR TITLE
Always show why a job is not managed

### DIFF
--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -76,23 +76,23 @@ class LazyJenkins(object):
 
         for name, job in self.get_jobs():
             if not match(name, self.jobs_filter):
-                logger.debug("Skipping %s", name)
+                logger.info("Skipping %s", name)
                 continue
 
             job = Job.factory(job)
             if job.polled_by_jenkins:
-                logger.debug("Skipping %s, polled by Jenkins", name)
+                logger.info("Skipping %s, polled by Jenkins", name)
                 continue
 
             # This option works only with webhook, so we can safely use it to
             # mark a job for jenkins-ghp.
             if not job.push_trigger:
-                logger.debug("Skipping %s, trigger on push disabled", name)
+                logger.info("Skipping %s, trigger on push disabled", name)
                 continue
 
             for project in job.get_projects():
                 if not match(str(project), self.projects_filter):
-                    logger.debug("Skipping %s", project)
+                    logger.info("Skipping %s", project)
                     continue
 
                 logger.info("Managing %s", name)

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -80,18 +80,19 @@ class LazyJenkins(object):
                 continue
 
             job = Job.factory(job)
-            if job.polled_by_jenkins:
+            if SETTINGS.GHP_JOBS_AUTO and job.polled_by_jenkins:
                 logger.info("Skipping %s, polled by Jenkins", name)
                 continue
 
             # This option works only with webhook, so we can safely use it to
             # mark a job for jenkins-ghp.
-            if not job.push_trigger:
+            if SETTINGS.GHP_JOBS_AUTO and not job.push_trigger:
                 logger.info("Skipping %s, trigger on push disabled", name)
                 continue
 
             for project in job.get_projects():
-                if not match(str(project), self.projects_filter):
+                project_match = match(str(project), self.projects_filter)
+                if SETTINGS.GHP_JOBS_AUTO and not project_match:
                     logger.info("Skipping %s", project)
                     continue
 

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -74,6 +74,10 @@ class LazyJenkins(object):
 
         projects = {}
 
+        if not SETTINGS.GHP_JOBS_AUTO and not self.jobs_filter:
+            logger.warn("Use GHP_JOBS env var to list jobs to managed")
+            return []
+
         for name, job in self.get_jobs():
             if not match(name, self.jobs_filter):
                 logger.info("Skipping %s", name)

--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -44,6 +44,7 @@ SETTINGS = EnvironmentSettings(defaults={
     'GHP_GITHUB_RO': False,
     'GHP_IGNORE_STATUSES': '',
     'GHP_JOBS': '',
+    'GHP_JOBS_AUTO': True,
     # Trigger loop
     'GHP_LOOP': 0,
     # When commenting on PR


### PR DESCRIPTION
cc @jpic 

```console
$ GHP_JOBS_AUTO=0 jenkins-ghp list-jobs
...
```