### PR TITLE
Don't try to parse None PR description

### DIFF
--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -147,6 +147,9 @@ class PullRequest(object):
         )
         comments = [issue.get()] + issue.comments.get()
         for comment in comments:
+            if comment['body'] is None:
+                continue
+
             body = comment['body'].replace('\r', '')
 
             for instruction in self.instruction_re.findall(body):


### PR DESCRIPTION
Fixes::

    [jenkins_ghp                 ERROR] Unhandled error
    Traceback (most recent call last):
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 84, in command_exitcode
        command_func()
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 58, in bot
        bot.run(pr)
      File "/home/jpic/env/src/ghp/jenkins_ghp/bot.py", line 61, in run
        self.process_instructions()
      File "/home/jpic/env/src/ghp/jenkins_ghp/bot.py", line 69, in process_instructions
        for date, author, data in self.pr.list_instructions():
      File "/home/jpic/env/src/ghp/jenkins_ghp/project.py", line 150, in list_instructions
        body = comment['body'].replace('\r', '')
    AttributeError: 'NoneType' object has no attribute 'replace'