### PR TITLE
Historical repo support

### DIFF
--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -296,13 +296,13 @@ class FixStatusExtension(Extension):
             if status['state'] == 'success':
                 continue
 
-            # Jenkins did not assign a build to this SHA1
-            if not status['target_url']:
-                continue
-
             updated_at = parse_datetime(status['updated_at'])
             # Don't poll Jenkins more than each 5 min.
             if status['state'] == 'pending' and updated_at > fivemin_ago:
+                continue
+
+            # There is no build URL.
+            if status['description'] in {'Backed', 'New', 'Queued'}:
                 continue
 
             # We mark actual failed with a bang to avoid rechecking it is

--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -310,7 +310,7 @@ class FixStatusExtension(Extension):
             if status['description'].endswith('!'):
                 continue
 
-            logger.info("Query %s status on Jenkins", context)
+            logger.debug("Query %s status on Jenkins", context)
             try:
                 build = JENKINS.get_build_from_url(status['target_url'])
             except Exception as e:

--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -42,7 +42,7 @@ class Bot(object):
             cls = ep.load()
             self.extensions[ep.name] = ext = cls(ep.name, self)
             SETTINGS.load(ext.SETTINGS)
-            logger.info("Loaded extension %s", ep.name)
+            logger.debug("Loaded extension %s", ep.name)
 
     def workon(self, pr):
         logger.info("Working on %s", pr)

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -80,29 +80,29 @@ class LazyJenkins(object):
 
         for name, job in self.get_jobs():
             if not match(name, self.jobs_filter):
-                logger.info("Skipping %s", name)
+                logger.debug("Skipping %s", name)
                 continue
 
             job = Job.factory(job)
             if SETTINGS.GHP_JOBS_AUTO and job.polled_by_jenkins:
-                logger.info("Skipping %s, polled by Jenkins", name)
+                logger.debug("Skipping %s, polled by Jenkins", name)
                 continue
 
             # This option works only with webhook, so we can safely use it to
             # mark a job for jenkins-ghp.
             if SETTINGS.GHP_JOBS_AUTO and not job.push_trigger:
-                logger.info("Skipping %s, trigger on push disabled", name)
+                logger.debug("Skipping %s, trigger on push disabled", name)
                 continue
 
             job_projects = [x for x in job.get_projects()]
             if not job_projects:
-                logger.info("Skipping %s, no GitHub project to poll", name)
+                logger.debug("Skipping %s, no GitHub project to poll", name)
                 continue
 
             for project in job_projects:
                 project_match = match(str(project), self.projects_filter)
                 if SETTINGS.GHP_JOBS_AUTO and not project_match:
-                    logger.info("Skipping %s", project)
+                    logger.debug("Skipping %s", project)
                     continue
 
                 logger.info("Managing %s", name)

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -169,6 +169,7 @@ class PullRequest(object):
             .issues(self.data['number'])
         )
         comments = [issue.get()] + issue.comments.get()
+        instructions = []
         for comment in comments:
             if comment['body'] is None:
                 continue
@@ -180,11 +181,12 @@ class PullRequest(object):
                 if instruction.startswith('yaml\n'):
                     instruction = instruction[4:].strip()
 
-                yield (
+                instructions.append((
                     parse_datetime(comment['updated_at']),
                     comment['user']['login'],
                     instruction,
-                )
+                ))
+        return instructions
 
     @retry(wait_fixed=15000)
     def update_statuses(self, context, state, description, target_url=None):

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -106,7 +106,7 @@ class PullRequest(object):
                 logger.debug("Skip GitHub statuses")
                 statuses = {}
             else:
-                logger.info(
+                logger.debug(
                     "Fetching statuses for %s", self.data['head']['sha'][:8]
                 )
                 url = 'https://api.github.com/repos/%s/%s/status/%s?access_token=%s&per_page=100' % (  # noqa
@@ -140,7 +140,7 @@ class PullRequest(object):
 
     @retry(wait_fixed=15000)
     def list_instructions(self):
-        logger.info("Queyring comments for instructions")
+        logger.debug("Queyring comments for instructions")
         issue = (
             GITHUB.repos(self.project.owner)(self.project.repository)
             .issues(self.data['number'])
@@ -225,7 +225,7 @@ class Project(object):
 
     @retry(wait_fixed=15000)
     def list_pull_requests(self):
-        logger.info(
+        logger.debug(
             "Querying GitHub for %s/%s PR", self.owner, self.repository,
         )
 

--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -50,6 +50,7 @@ SETTINGS = EnvironmentSettings(defaults={
     # When commenting on PR
     'GHP_NAME': 'Jenkins GitHub Builder',
     'GHP_PR': '',
+    'GHP_PR_MAX_WEEKS': '',
     'GHP_PROJECTS': '',
     'GHP_VERBOSE': '',
     'GITHUB_TOKEN': None,


### PR DESCRIPTION
This PR makes jenkins_ghb a bit more usable on historical repositories.

On one of our internal repos, that's a change from 707 lines of log to 261. There's still a bit more work to do though, hence WIP in the PR title.

Here's an extract of the diff:

```
 [ERROR   ] Failed request at http://example.com/job/yourrepo/MATRIX_AXIS=sentry_masterless/120/api/python with params: {'depth': 1}
-[WARNING ] Failed to get actual build status: Exception: Build http://example.com/job/yourrepo/MATRIX_AXIS=sentry_masterless/120 not found. Lost ?
-[INFO    ] Would update status yourrepo/MATRIX_AXIS=sentry_masterless to pending/Backed
-[INFO    ] Query yourrepo/MATRIX_AXIS=sftp_masterless status on Jenkins
 [ERROR   ] Failed request at http://example.com/job/yourrepo/MATRIX_AXIS=sftp_masterless/335/api/python with params: {'depth': 1}
-[WARNING ] Failed to get actual build status: Exception: Build http://example.com/job/yourrepo/MATRIX_AXIS=sftp_masterless/335 not found. Lost ?
-[INFO    ] Would update status yourrepo/MATRIX_AXIS=sftp_masterless to pending/Backed
-[INFO    ] Query yourrepo/MATRIX_AXIS=sign_masterless status on Jenkins
 [ERROR   ] Failed request at http://example.com/job/yourrepo/MATRIX_AXIS=sign_masterless/120/api/python with params: {'depth': 1}
-[WARNING ] Failed to get actual build status: Exception: Build http://example.com/job/yourrepo/MATRIX_AXIS=sign_masterless/120 not found. Lost ?
-[INFO    ] Would update status yourrepo/MATRIX_AXIS=sign_masterless to pending/Backed
-[INFO    ] Query yourrepo/MATRIX_AXIS=supernova_masterless status on Jenkins
 [ERROR   ] Failed request at http://example.com/job/yourrepo/MATRIX_AXIS=supernova_masterless/335/api/python with params: {'depth': 1}
-[WARNING ] Failed to get actual build status: Exception: Build http://example.com/job/yourrepo/MATRIX_AXIS=supernova_masterless/335 not found. Lost ?
-[INFO    ] Would update status yourrepo/MATRIX_AXIS=supernova_masterless to pending/Backed
-[INFO    ] Query yourrepo/MATRIX_AXIS=syslog_masterless status on Jenkins
 [ERROR   ] Failed request at http://example.com/job/yourrepo/MATRIX_AXIS=syslog_masterless/120/api/python with params: {'depth': 1}
-[WARNING ] Failed to get actual build status: Exception: Build http://example.com/job/yourrepo/MATRIX_AXIS=syslog_masterless/120 not found. Lost ?
-[INFO    ] Would update status yourrepo/MATRIX_AXIS=syslog_masterless to pending/Backed
+[WARNING ] Failed to get actual build status for contexts: ['yourrepo/MATRIX_AXIS=audit_masterless', 'novasalt/MATRIX_AXIS=bind_masterless', 'novasalt/MATRIX_AXIS=connect_masterless', 'novasalt/MATRIX_AXIS=delivery_masterless', 'novasalt/MATRIX_AXIS=eeyore_masterless', 'novasalt/MATRIX_AXIS=flow_masterless', 'novasalt/MATRIX_AXIS=keynectis_masterless', 'novasalt/MATRIX_AXIS=mark_masterless', 'novasalt/MATRIX_AXIS=masterless_insight', 'novasalt/MATRIX_AXIS=novaauth_masterless', 'novasalt/MATRIX_AXIS=novacoreserver_masterless', 'novasalt/MATRIX_AXIS=novapostme_masterless', 'novasalt/MATRIX_AXIS=opentrust_masterless', 'novasalt/MATRIX_AXIS=peopleask_masterless', 'novasalt/MATRIX_AXIS=peopledoc_masterless', 'novasalt/MATRIX_AXIS=peopleinvitation_masterless', 'novasalt/MATRIX_AXIS=redis_masterless', 'novasalt/MATRIX_AXIS=sae_masterless', 'novasalt/MATRIX_AXIS=sae_mock_masterless', 'novasalt/MATRIX_AXIS=sentry_masterless', 'novasalt/MATRIX_AXIS=sftp_masterless', 'novasalt/MATRIX_AXIS=sign_masterless', 'novasalt/MATRIX_AXIS=supernova_masterless', 'novasalt/MATRIX_AXIS=syslog_masterless']
```