### PR TITLE
Urgent PR

### DIFF
--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -358,6 +358,9 @@ jenkins: ignore
 %(mentions)s: this is what I understand:
 
 ```yaml
+# Build this PR first. Allowed only in PR description.
+jenkins: urgent
+
 %(help)s
 ```
 

--- a/jenkins_ghp/main.py
+++ b/jenkins_ghp/main.py
@@ -49,6 +49,11 @@ def loop(wrapped):
 
 @asyncio.coroutine
 def check_queue(bot):
+    if SETTINGS.GHP_ALWAYS_QUEUE:
+        logger.info("Ignoring queue status. New jobs will be queued.")
+        bot.queue_empty = True
+        return
+
     old, bot.queue_empty = bot.queue_empty, JENKINS.is_queue_empty()
     if not bot.queue_empty:
         yield from asyncio.sleep(5)

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -230,7 +230,7 @@ class Project(object):
                 pulls_o.append(pr)
             else:
                 logger.debug("Skipping %s", pr)
-        return pulls_o
+        return reversed(sorted(pulls_o, key=PullRequest.sort_key))
 
     def list_contexts(self):
         for job in self.jobs:

--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -36,6 +36,7 @@ class EnvironmentSettings(object):
 
 
 SETTINGS = EnvironmentSettings(defaults={
+    'GHP_ALWAYS_QUEUE': False,
     'GHP_BRANCHES': '',
     'GHP_CACHE_PATH': '.ghp-cache',
     'GHP_COMMIT_MAX_WEEKS': '',

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -83,3 +83,32 @@ jenkins: unix_eof
     assert 'indent:' in haystack
     assert 'colored:' in haystack
     assert 'unix_eof' in haystack
+
+
+def test_pr_urgent():
+    from jenkins_ghp.project import PullRequest
+
+    pr1 = PullRequest(data=dict(
+        head=dict(sha='01234567899abcdef', ref='pr1'),
+        body='',
+        html_url='pulls/1',
+    ), project=Mock())
+    assert not pr1.urgent
+    pr2 = PullRequest(data=dict(
+        head=dict(sha='01234567899abcdef', ref='pr2'),
+        body='jenkins: urgent',
+        html_url='pulls/2',
+    ), project=Mock())
+    assert pr2.urgent
+    pr3 = PullRequest(data=dict(
+        head=dict(sha='01234567899abcdef', ref='pr3'),
+        body='> jenkins: urgent',
+        html_url='pulls/3',
+    ), project=Mock())
+    assert not pr3.urgent
+
+    github_listing = [pr3, pr2, pr1]
+    build_listing = [pr1, pr3, pr2]
+    assert build_listing == sorted(
+        github_listing, key=PullRequest.sort_key
+    )


### PR DESCRIPTION
J'aimerai créer une instruction `jenkins: urgent`. Mais le listage n'est pas gérée par le bot.