### PR TITLE
Support unindented instructions

### DIFF
--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -78,12 +78,19 @@ class Bot(object):
         process = True
         for date, author, data in self.head.list_instructions():
             try:
-                data = yaml.load(data)
+                payload = yaml.load(data)
             except yaml.error.YAMLError as e:
                 self.settings['errors'].append((author, data, e))
                 continue
 
-            data = data['jenkins']
+            data = payload.pop('jenkins')
+            # If jenkins is empty, reset to dict
+            data = data or {}
+            # If spurious keys are passed, this may be an unindented yaml, just
+            # include it.
+            if payload:
+                data = dict(payload, **data)
+
             if not data:
                 continue
             if isinstance(data, str):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,6 +1,21 @@
 from mock import Mock
 
 
+def test_compute_skip_unindented():
+    from jenkins_ghp.bot import Bot
+
+    pr = Mock()
+    pr.list_jobs.return_value = []
+    pr.list_instructions.return_value = [
+        (0, 0, 'jenkins:\nskip: [toto]\n'),
+    ]
+
+    bot = Bot().workon(pr)
+    bot.process_instructions()
+    skip = [re.pattern for re in bot.settings['skip']]
+    assert ['toto'] == skip
+
+
 def test_compute_skip_null():
     from jenkins_ghp.bot import Bot, BuilderExtension
 


### PR DESCRIPTION
Always be happy with users. We encounterd such instructions comments:

    ```
    jenkins:
    skip: [my-irrelevant-job]
    ```

Let's support this.