### PR TITLE
Merge GHP_BRANCHES and GHP_REPOSITORIES

### DIFF
--- a/jenkins_ghp/main.py
+++ b/jenkins_ghp/main.py
@@ -68,14 +68,11 @@ def check_queue(bot):
 
 def list_all_projects():
     projects = set()
-    repositories = filter(None, SETTINGS.GHP_REPOSITORIES.split(','))
 
     for project in JENKINS.list_projects():
         projects.add(project)
 
-    for repository in repositories:
-        owner, repository = repository.split('/')
-        project = Project(owner, repository)
+    for project in Project.list_projects():
         projects.add(project)
 
     return sorted(list(projects), key=str)

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -135,7 +135,7 @@ class Project(object):
         r'.*github.com[:/](?P<owner>[\w-]+)/(?P<repository>[\w-]+).*'
     )
     pr_filter = [p for p in SETTINGS.GHP_PR.split(',') if p]
-    _branches_settings = None
+    _repositories_settings = None
 
     @classmethod
     def from_remote(cls, remote_url):
@@ -143,6 +143,21 @@ class Project(object):
         if not match:
             raise ValueError('%r is not github' % (remote_url,))
         return cls(**match.groupdict())
+
+    @classmethod
+    def list_projects(cls):
+        if cls._repositories_settings is None:
+            cls._repositories_settings = {}
+            repositories = filter(None, SETTINGS.GHP_REPOSITORIES.split(' '))
+            for repository in repositories:
+                repository, branches = repository.split(':')
+                cls._repositories_settings[repository] = [
+                    'refs/heads/' + b for b in branches.split(',') if b
+                ]
+
+        for repository in cls._repositories_settings:
+            owner, repository = repository.split('/')
+            yield Project(owner, repository)
 
     def __init__(self, owner, repository, jobs=None):
         self.owner = owner
@@ -158,22 +173,14 @@ class Project(object):
     def __str__(self):
         return '%s/%s' % (self.owner, self.repository)
 
+    __repr__ = __str__
+
     @property
     def url(self):
         return 'https://github.com/%s/%s' % (self.owner, self.repository)
 
     def branches_settings(self):
-        if self._branches_settings is None:
-            # Parse GHP_BRANCHES
-            Project._branches_settings = {}
-            for project in SETTINGS.GHP_BRANCHES.split(' '):
-                if not project.strip():
-                    continue
-                project, branches = project.split(':')
-                Project._branches_settings[project] = [
-                    'refs/heads/' + b for b in branches.split(',')
-                ]
-        return self._branches_settings.get(str(self), [])
+        return self._repositories_settings.get(str(self), [])
 
     @retry(wait_fixed=15000)
     def list_branches(self):

--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -37,7 +37,6 @@ class EnvironmentSettings(object):
 
 SETTINGS = EnvironmentSettings(defaults={
     'GHP_ALWAYS_QUEUE': False,
-    'GHP_BRANCHES': '',
     'GHP_CACHE_PATH': '.ghp-cache',
     'GHP_COMMIT_MAX_WEEKS': '',
     # Drop into Pdb on unhandled exception
@@ -59,6 +58,8 @@ SETTINGS = EnvironmentSettings(defaults={
     # When commenting on PR
     'GHP_NAME': 'Jenkins GitHub Builder',
     'GHP_PR': '',
+    # List repositories and their main branches:
+    #   'owner/repo1:master owner/repo2:master,stable'
     'GHP_REPOSITORIES': '',
     'GHP_VERBOSE': '',
     'GITHUB_TOKEN': None,

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,29 @@
+from mock import patch
+
+
+@patch('jenkins_ghp.project.SETTINGS')
+def test_list_projects(SETTINGS):
+    from jenkins_ghp.project import Project
+
+    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master"
+    Project._repositories_settings = None
+    projects = [p for p in Project.list_projects()]
+    assert 'owner/repo1' in Project._repositories_settings
+    assert 1 == len(projects)
+
+    Project._repositories_settings = None
+    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master,stable owner/repo2:"
+    projects = {str(p): p for p in Project.list_projects()}
+    assert 2 == len(projects)
+    assert 'owner/repo1' in Project._repositories_settings
+    assert (
+        ['refs/heads/master', 'refs/heads/stable'] ==
+        Project._repositories_settings['owner/repo1']
+    )
+    assert 'owner/repo2' in Project._repositories_settings
+    assert [] == Project._repositories_settings['owner/repo2']
+
+    assert (
+        ['refs/heads/master', 'refs/heads/stable'] ==
+        projects['owner/repo1'].branches_settings()
+    )


### PR DESCRIPTION
En fait, c'est vraiment inutiles de lister deux fois les projets. J'aurai pas dû créé GHP_REPOSITORIES car on ne veut pas gérer un dépôt sans testers sa branches.