### PR TITLE
Add GHP_RATE_LIMIT_THRESHOLD

### DIFF
--- a/jenkins_ghp/settings.py
+++ b/jenkins_ghp/settings.py
@@ -58,6 +58,7 @@ SETTINGS = EnvironmentSettings(defaults={
     # When commenting on PR
     'GHP_NAME': 'Jenkins GitHub Builder',
     'GHP_PR': '',
+    'GHP_RATE_LIMIT_THRESHOLD': 250,
     # List repositories and their main branches:
     #   'owner/repo1:master owner/repo2:master,stable'
     'GHP_REPOSITORIES': '',

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -3,6 +3,8 @@ from mock import Mock, patch
 
 @patch('jenkins_ghp.project.GITHUB')
 def test_parse(GITHUB):
+    GITHUB.x_ratelimit_remaining = 4999
+
     updated_at = '2016-02-12T16:32:34Z'
     from jenkins_ghp.project import PullRequest
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,5 @@
-from mock import patch
+from mock import patch, Mock
+import pytest
 
 
 @patch('jenkins_ghp.project.SETTINGS')
@@ -27,3 +28,15 @@ def test_list_projects(SETTINGS):
         ['refs/heads/master', 'refs/heads/stable'] ==
         projects['owner/repo1'].branches_settings()
     )
+
+
+@patch('jenkins_ghp.project.SETTINGS')
+@patch('jenkins_ghp.project.GITHUB')
+def test_threshold(GITHUB, SETTINGS):
+    from jenkins_ghp.project import cached_request, ApiError
+
+    SETTINGS.GHP_RATE_LIMIT_THRESHOLD = 3000
+    GITHUB.x_ratelimit_remaining = 2999
+
+    with pytest.raises(ApiError):
+        cached_request(Mock())


### PR DESCRIPTION
Since Jenkins does not retry on rate limit exceeded, we set a threshold
where GHP stops hammering GitHub to let remaining hit to Jenkins. This
fixes build failing with :

    Setting commit status on GitHub for https://github.com/owner/repo/commit/sha1
    ERROR: Step ‘Set build status on GitHub commit’ aborted due to exception:
    java.io.IOException: API rate limit reached
            at org.kohsuke.github.RateLimitHandler$2.onError(RateLimitHandler.java:58)
            at org.kohsuke.github.Requester.handleApiError(Requester.java:518)