### PR TITLE
Fix ValueError: sleep length must be non-negative

### DIFF
--- a/jenkins_ghp/utils.py
+++ b/jenkins_ghp/utils.py
@@ -93,4 +93,4 @@ def wait_rate_limit_reset():
     now = int(time.time())
     wait = GITHUB.x_ratelimit_reset - now + 5
     logger.info("Waiting rate limit reset in %s seconds", wait)
-    time.sleep(wait)
+    time.sleep(wait if wait > 0 else 0)


### PR DESCRIPTION
    [jenkins_ghp.project         DEBUG] GitHub hit rate limit threshold exceeded.
    [jenkins_ghp.utils            INFO] Waiting rate limit reset in -15 seconds
    [jenkins_ghp                 ERROR] Unhandled error
    Traceback (most recent call last):
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 129, in command_exitcode
        command_func()
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 172, in run_async
        loop.run_until_complete(task)
      File "/usr/lib/python3.4/asyncio/base_events.py", line 276, in run_until_complete
        return future.result()
      File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
        raise self._exception
      File "/usr/lib/python3.4/asyncio/tasks.py", line 237, in _step
        result = next(coro)
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 40, in wrapper
        yield from res
      File "/home/jpic/env/src/ghp/jenkins_ghp/main.py", line 93, in bot
        bot.run(pr)
      File "/home/jpic/env/src/ghp/jenkins_ghp/bot.py", line 75, in run
        ext.end()
      File "/home/jpic/env/src/ghp/jenkins_ghp/bot.py", line 205, in end
        rebuild_failed=self.bot.settings['rebuild-failed']
      File "/home/jpic/env/src/ghp/jenkins_ghp/project.py", line 377, in filter_not_built_contexts
        status = self.get_status_for(context)
      File "/home/jpic/env/src/ghp/jenkins_ghp/project.py", line 426, in get_status_for
        return self.get_statuses().get(context, {})
      File "/home/jpic/env/src/ghp/.tox/py34/lib/python3.4/site-packages/retrying.py", line 49, in wrapped_f
        return Retrying(*dargs, **dkw).call(f, *args, **kw)
      File "/home/jpic/env/src/ghp/.tox/py34/lib/python3.4/site-packages/retrying.py", line 205, in call
        if not self.should_reject(attempt):
      File "/home/jpic/env/src/ghp/.tox/py34/lib/python3.4/site-packages/retrying.py", line 189, in should_reject
        reject |= self._retry_on_exception(attempt.value[1])
      File "/home/jpic/env/src/ghp/jenkins_ghp/utils.py", line 36, in retry_filter
        wait_rate_limit_reset()
      File "/home/jpic/env/src/ghp/jenkins_ghp/utils.py", line 96, in wait_rate_limit_reset
        time.sleep(wait)
    ValueError: sleep length must be non-negative