### PR TITLE
Refactorize list_projects

### DIFF
--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -107,6 +107,17 @@ class LazyJenkins(object):
                 project = projects.setdefault(str(project), project)
                 project.jobs.append(job)
 
+        repositories = filter(None, SETTINGS.GHP_REPOSITORIES.split(' '))
+        for entry in repositories:
+            project, branches = entry.split(':')
+            owner, repository = project.split('/')
+            project = projects.setdefault(
+                project, Project(owner, repository)
+            )
+            project.branches_settings = [
+                'refs/heads/' + b for b in branches.split(',') if b
+            ]
+
         return sorted(projects.values(), key=str)
 
     @retry

--- a/jenkins_ghp/main.py
+++ b/jenkins_ghp/main.py
@@ -22,7 +22,6 @@ import sys
 
 from .bot import Bot
 from .cache import CACHE
-from .project import Project
 from .jenkins import JENKINS
 from .settings import SETTINGS
 
@@ -66,24 +65,12 @@ def check_queue(bot):
         logger.warn("Queue is full. No jobs will be queued.")
 
 
-def list_all_projects():
-    projects = set()
-
-    for project in JENKINS.list_projects():
-        projects.add(project)
-
-    for project in Project.list_projects():
-        projects.add(project)
-
-    return sorted(list(projects), key=str)
-
-
 @loop
 @asyncio.coroutine
 def bot():
     """Poll GitHub to find something to do"""
     bot = Bot(queue_empty=None)
-    for project in list_all_projects():
+    for project in JENKINS.list_projects():
         for branch in project.list_branches():
             yield from check_queue(bot)
             bot.run(branch)
@@ -97,7 +84,7 @@ def bot():
 
 def list_jobs():
     """List managed jobs"""
-    for project in list_all_projects():
+    for project in JENKINS.list_projects():
         for job in project.jobs:
             print(job)
 
@@ -105,14 +92,14 @@ def list_jobs():
 def list_branches():
     """List branches to build"""
 
-    for project in list_all_projects():
+    for project in JENKINS.list_projects():
         for branch in project.list_branches():
             print(branch)
 
 
 def list_pr():
     """List GitHub PR polled"""
-    for project in list_all_projects():
+    for project in JENKINS.list_projects():
         for pr in project.list_pull_requests():
             print(pr)
 
@@ -120,7 +107,7 @@ def list_pr():
 def list_projects():
     """List GitHub projects tested by this Jenkins"""
 
-    for project in list_all_projects():
+    for project in JENKINS.list_projects():
         print(project)
 
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+
+@patch('jenkins_ghp.jenkins.Jenkins')
+@patch('jenkins_ghp.jenkins.SETTINGS')
+def test_list_projects(SETTINGS, Jenkins):
+    from jenkins_ghp.jenkins import JENKINS
+
+    Jenkins.return_value.get_jobs.return_value = []
+
+    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master"
+    projects = JENKINS.list_projects()
+    assert 1 == len(projects)
+
+    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master,stable owner/repo2:"
+    projects = {str(p): p for p in JENKINS.list_projects()}
+    assert 2 == len(projects)
+    assert 'owner/repo1' in projects
+    assert (
+        ['refs/heads/master', 'refs/heads/stable'] ==
+        projects['owner/repo1'].branches_settings
+    )
+    assert 'owner/repo2' in projects
+    assert [] == projects['owner/repo2'].branches_settings

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -4,34 +4,6 @@ import pytest
 
 
 @patch('jenkins_ghp.project.SETTINGS')
-def test_list_projects(SETTINGS):
-    from jenkins_ghp.project import Project
-
-    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master"
-    Project._repositories_settings = None
-    projects = [p for p in Project.list_projects()]
-    assert 'owner/repo1' in Project._repositories_settings
-    assert 1 == len(projects)
-
-    Project._repositories_settings = None
-    SETTINGS.GHP_REPOSITORIES = "owner/repo1:master,stable owner/repo2:"
-    projects = {str(p): p for p in Project.list_projects()}
-    assert 2 == len(projects)
-    assert 'owner/repo1' in Project._repositories_settings
-    assert (
-        ['refs/heads/master', 'refs/heads/stable'] ==
-        Project._repositories_settings['owner/repo1']
-    )
-    assert 'owner/repo2' in Project._repositories_settings
-    assert [] == Project._repositories_settings['owner/repo2']
-
-    assert (
-        ['refs/heads/master', 'refs/heads/stable'] ==
-        projects['owner/repo1'].branches_settings()
-    )
-
-
-@patch('jenkins_ghp.project.SETTINGS')
 @patch('jenkins_ghp.project.GITHUB')
 def test_threshold(GITHUB, SETTINGS):
     from jenkins_ghp.project import cached_request, ApiError


### PR DESCRIPTION
The purpose of this changes is to let the CI server maintain the list of
managed projects. Since Jenkins1 does not managed project without jobs,
the JENKINS client complete Jenkins introspection with values from
settings.

Anyway, the CI server si also responsible to known which branches to
build. This si considered a CI settings, not in poller. So we add
branches listing right in project listing.