### PR TITLE
Various fixes

### DIFF
--- a/jenkins_ghp/cache.py
+++ b/jenkins_ghp/cache.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Cache(object):
     def get(self, key):
         try:
-            value = self.storage[key]
+            _, value = self.storage[key]
             logger.debug("Hit %s", key)
             return value
         except KeyError:

--- a/jenkins_ghp/jobs/freestyle.xml
+++ b/jenkins_ghp/jobs/freestyle.xml
@@ -80,16 +80,7 @@
       <command>{{ command }}</command>
     </hudson.tasks.Shell>
   </builders>
-{%- if publish %}
-  <publishers>
-    <com.cloudbees.jenkins.GitHubCommitNotifier plugin="github@1.17.0">
-      <statusMessage>
-        <content></content>
-      </statusMessage>
-      <resultOnFailure>FAILURE</resultOnFailure>
-    </com.cloudbees.jenkins.GitHubCommitNotifier>
-  </publishers>
-{%- endif %}
+  <publishers/>
   <buildWrappers>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
       <colorMapName>gnome-terminal</colorMapName>

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -544,4 +544,4 @@ class PullRequest(Head):
             GITHUB.repos(self.project.owner)(self.project.repository)
             .issues(self.data['number'])
         )
-        return [cached_request(issue)] + cached_request(issue.comments)
+        return [self.data] + cached_request(issue.comments)

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -103,6 +103,9 @@ class CustomGitHub(GitHub):
         for k, v in headers.items():
             request.add_header(k, v)
         try:
+            logger.debug(
+                "%s %s remaining=%s", _method, url, self.x_ratelimit_remaining
+            )
             response = opener.open(request, timeout=TIMEOUT)
             is_json = self._process_resp(response.headers)
             if is_json:

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -42,7 +42,10 @@ def check_rate_limit_threshold():
         # Cool, we didn't hit our threshold
         return
 
-    logger.debug("GitHub hit rate limit threshold exceeded.")
+    logger.debug(
+        "GitHub hit rate limit threshold exceeded. (remaining=%s)",
+        GITHUB.x_ratelimit_remaining,
+    )
     # Fake rate limit exceeded
     raise ApiError(url='any', request={}, response=dict(code='403', json=dict(
         message="API rate limit exceeded for 0.0.0.0"

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -510,7 +510,7 @@ class PullRequest(Head):
         # Return sort data. Higher is more urgent. By defaults, last PR is
         # built first. This avoid building staled PR first. It's the default
         # order of GitHub PR listing.
-        return self.urgent, self.data['html_url']
+        return self.urgent, self.data['number']
 
     def __str__(self):
         return '%s (%s)' % (self.data['html_url'], self.ref)

--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -513,7 +513,7 @@ class PullRequest(Head):
         )
         self.data = data
         body = (data.get('body') or '').replace('\r', '')
-        self.urgent = bool(self._urgent_re.match(body))
+        self.urgent = bool(self._urgent_re.search(body))
 
     def sort_key(self):
         # Return sort data. Higher is more urgent. By defaults, last PR is

--- a/jenkins_ghp/utils.py
+++ b/jenkins_ghp/utils.py
@@ -93,7 +93,7 @@ def wait_rate_limit_reset():
     now = int(time.time())
     wait = GITHUB.x_ratelimit_reset - now + 5
     if wait < 0:
-        # This is rate limit GHP threshold. Overwrite reset timestamp.
-        wait = 2100
+        wait = 300
     logger.info("Waiting rate limit reset in %s seconds", wait)
     time.sleep(wait)
+    GITHUB._instance.x_ratelimit_remaining = -1

--- a/jenkins_ghp/utils.py
+++ b/jenkins_ghp/utils.py
@@ -19,6 +19,7 @@ import time
 
 import retrying
 from github import ApiError
+import http.client
 
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ def retry_filter(exception):
         # If not a rate limit error, don't retry.
         return False
 
-    if not isinstance(exception, IOError):
+    if not isinstance(exception, (IOError, http.client.HTTPException)):
         return False
 
     logger.warn(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,7 +15,7 @@ def test_purge(SETTINGS):
     with freeze_time('2012-12-21 00:00:00 UTC') as time:
         cache.set('key', 'data')
         cache.purge()
-        date, data = cache.get('key')
+        data = cache.get('key')
         assert 'data' == data
 
         time.tick(timedelta(seconds=21))

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -9,15 +9,16 @@ def test_parse(GITHUB):
     from jenkins_ghp.project import PullRequest
 
     pr = PullRequest(
-        {'number': '123', 'head': {'sha': 'c01', 'ref': 'toto'}},
+        {
+            'number': '123', 'head': {'sha': 'c01', 'ref': 'toto'},
+            'updated_at': updated_at,
+            'body': 'jenkins: issue',
+            'user': {'login': 'reporter'},
+        },
         Mock(),
     )
     # GITHUB.repos(owner)(repository).issues(id).comments
     issue = GITHUB.repos.return_value.return_value.issues.return_value
-    issue.get.return_value = {
-        'updated_at': updated_at, 'body': 'jenkins: issue',
-        'user': {'login': 'reporter'},
-    }
     issue.comments.get.return_value = [
         {
             'body': body,

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -21,7 +21,7 @@ def test_parse(GITHUB):
     issue.comments.get.return_value = [
         {
             'body': body,
-            'html_url': 'URL' + repr(body),
+            'number': len(body),
             'updated_at': updated_at,
             'user': {'login': 'commenter'},
         } for body in [
@@ -93,24 +93,30 @@ def test_pr_urgent():
     pr1 = PullRequest(data=dict(
         head=dict(sha='01234567899abcdef', ref='pr1'),
         body=None,
-        html_url='pulls/1',
+        number=1, html_url='pulls/1',
     ), project=Mock())
     assert not pr1.urgent
     pr2 = PullRequest(data=dict(
         head=dict(sha='01234567899abcdef', ref='pr2'),
         body='jenkins: urgent',
-        html_url='pulls/2',
+        number=2, html_url='pulls/2',
     ), project=Mock())
     assert pr2.urgent
     pr3 = PullRequest(data=dict(
         head=dict(sha='01234567899abcdef', ref='pr3'),
         body='> jenkins: urgent',
-        html_url='pulls/3',
+        number=3, html_url='pulls/3',
     ), project=Mock())
     assert not pr3.urgent
+    pr10 = PullRequest(data=dict(
+        head=dict(sha='01234567899abcdef', ref='pr3'),
+        body=None,
+        number=10, html_url='pulls/10',
+    ), project=Mock())
+    assert not pr10.urgent
 
-    github_listing = [pr3, pr2, pr1]
-    build_listing = [pr1, pr3, pr2]
+    github_listing = [pr10, pr3, pr2, pr1]
+    build_listing = [pr1, pr3, pr10, pr2]
     assert build_listing == sorted(
         github_listing, key=PullRequest.sort_key
     )

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -98,7 +98,7 @@ def test_pr_urgent():
     assert not pr1.urgent
     pr2 = PullRequest(data=dict(
         head=dict(sha='01234567899abcdef', ref='pr2'),
-        body='jenkins: urgent',
+        body='bla\n\njenkins: urgent',
         number=2, html_url='pulls/2',
     ), project=Mock())
     assert pr2.urgent


### PR DESCRIPTION
- Fix infinite loop on GitHub rate limit threshold hit
- Fix PR build order when queue get empty while walking through PR.
- Cache commit statuses in memory
- Retry on HTTPException
- Fix urgent PR priority parser
- Fix cache get value
- Do not requery PR body, saving one GitHub API hit per PR.