### PR TITLE
List jenkins yml

### DIFF
--- a/jenkins_ghp/project.py
+++ b/jenkins_ghp/project.py
@@ -168,7 +168,7 @@ class Project(object):
     remote_re = re.compile(
         r'.*github.com[:/](?P<owner>[\w-]+)/(?P<repository>[\w-]+).*'
     )
-    pr_filter = [p for p in SETTINGS.GHP_PR.split(',') if p]
+    pr_filter = [p for p in str(SETTINGS.GHP_PR).split(',') if p]
 
     @classmethod
     def from_remote(cls, remote_url):

--- a/jenkins_ghp/utils.py
+++ b/jenkins_ghp/utils.py
@@ -21,6 +21,8 @@ import retrying
 from github import ApiError
 import http.client
 
+from .settings import SETTINGS
+
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +95,7 @@ def wait_rate_limit_reset():
     now = int(time.time())
     wait = GITHUB.x_ratelimit_reset - now + 5
     if wait < 0:
-        wait = 300
+        wait = SETTINGS.GHP_LOOP or 60
     logger.info("Waiting rate limit reset in %s seconds", wait)
     time.sleep(wait)
     GITHUB._instance.x_ratelimit_remaining = -1


### PR DESCRIPTION
@jpic pour les projets sans `jenkins.yml`, ça devrait pas mal réduire les hits. Pour les autres, ça peut entrainer un peu plus de consommation lors de  modifications dans le dossier racine.