### PR TITLE
Poll rate_limit page

### DIFF
--- a/jenkins_ghp/cache.py
+++ b/jenkins_ghp/cache.py
@@ -112,6 +112,9 @@ class FileCache(Cache):
             return time.time(), value
 
     def purge(self):
+        if not self.lock:
+            return
+
         super(FileCache, self).purge()
         self.storage.sync()
 

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -194,7 +194,7 @@ class Job(object):
                         continue
 
                     for param in prop['parameterDefinitions']:
-                        if [param['name'] in r for r in refspecs]:
+                        if sum([param['name'] in r for r in refspecs]):
                             self._revision_param = param['name']
                             logger.debug(
                                 "Using %s param to specify revision for %s",


### PR DESCRIPTION
@jpic @toopy y'a un soucis. On attends parfois une heure alors que le rate limit est déjà réinitialisé. Donc je préfère poller.

selon la doc, la ressource `rate_limit` ne compte pas dans le même rate_limit.