### PR TITLE
Use protected branches as default branches

### DIFF
--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -118,9 +118,6 @@ class LazyJenkins(object):
             project = projects.setdefault(
                 project, Project(owner, repository)
             )
-            project.branches_settings = [
-                'refs/heads/' + b for b in branches.split(',') if b
-            ]
 
         return sorted(projects.values(), key=str)
 

--- a/jenkins_ghp/main.py
+++ b/jenkins_ghp/main.py
@@ -110,6 +110,7 @@ def bot():
 def list_jobs():
     """List managed jobs"""
     for project in JENKINS.list_projects():
+        project.fetch_settings()
         for job in project.jobs:
             print(job)
 
@@ -118,6 +119,7 @@ def list_branches():
     """List branches to build"""
 
     for project in JENKINS.list_projects():
+        project.fetch_settings()
         for branch in project.list_branches():
             print(branch)
 
@@ -125,6 +127,7 @@ def list_branches():
 def list_pr():
     """List GitHub PR polled"""
     for project in JENKINS.list_projects():
+        project.fetch_settings()
         for pr in project.list_pull_requests():
             print(pr)
 
@@ -133,6 +136,7 @@ def list_projects():
     """List GitHub projects tested by this Jenkins"""
 
     for project in JENKINS.list_projects():
+        project.fetch_settings()
         print(project)
 
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -16,9 +16,4 @@ def test_list_projects(SETTINGS, Jenkins):
     projects = {str(p): p for p in JENKINS.list_projects()}
     assert 2 == len(projects)
     assert 'owner/repo1' in projects
-    assert (
-        ['refs/heads/master', 'refs/heads/stable'] ==
-        projects['owner/repo1'].branches_settings
-    )
     assert 'owner/repo2' in projects
-    assert [] == projects['owner/repo2'].branches_settings

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -13,3 +13,31 @@ def test_threshold(GITHUB, SETTINGS):
 
     with pytest.raises(ApiError):
         cached_request(Mock())
+
+
+@patch('jenkins_ghp.project.Project.fetch_file_contents')
+@patch('jenkins_ghp.project.Project.fetch_default_settings')
+def test_fetch_settings_ghp(fds, ffc):
+    from jenkins_ghp.project import Project
+
+    fds.return_value = {}
+    ffc.return_value = repr(dict(
+        branches=['master', 'qualif', 'develop'],
+    ))
+
+    project = Project('owner', 'repo1')
+    project.fetch_settings()
+    assert ['master', 'qualif', 'develop'] == project.SETTINGS.GHP_BRANCHES
+
+
+@patch('jenkins_ghp.project.SETTINGS')
+@patch('jenkins_ghp.project.cached_request')
+def test_defaults_branches(cached_request, SETTINGS):
+    from jenkins_ghp.project import Project
+
+    SETTINGS.GHP_REPOSITORIES = 'owner/repo1:master owner/repo2:stable'
+    cached_request.return_value = []
+
+    project = Project('owner', 'repo1')
+    branches = project.list_watched_branches()
+    assert ['refs/heads/master'] == branches


### PR DESCRIPTION
Avec cette PR, les branches gérées par GHP sont par défaut toutes les branches protégées dans GitHub. On peut toujours les surcharger avec `GHP_REPOSITORIES`, mais ce settings me semble trop compliqué, ça me saoûle. En revanche, on peut aussi surcharger avec `.github/ghp.yml`:

```yaml
branches: [master, qualif]
```