### PR TITLE
Update jobs from spec

### DIFF
--- a/jenkins_ghp/bot.py
+++ b/jenkins_ghp/bot.py
@@ -111,6 +111,9 @@ Failed to create Jenkins job `%(name)s`.
         for spec in self.current.job_specs.values():
             if spec.name in self.current.jobs:
                 current_job = self.current.jobs[spec.name]
+                if not current_job.is_enabled():
+                    continue
+
                 if current_job.spec.contains(spec):
                     continue
 

--- a/jenkins_ghp/extensions.py
+++ b/jenkins_ghp/extensions.py
@@ -97,8 +97,8 @@ jenkins: reset-skip-errors
                 error=str(error),
             ))
 
-        for job in self.current.jobs.values():
-            spec = self.current.job_specs[job.name]
+        for spec in self.current.job_specs.values():
+            job = self.current.jobs[spec.name]
             not_built = self.current.head.filter_not_built_contexts(
                 job.list_contexts(spec),
                 rebuild_failed=self.current.rebuild_failed

--- a/jenkins_ghp/extensions.py
+++ b/jenkins_ghp/extensions.py
@@ -99,6 +99,9 @@ jenkins: reset-skip-errors
 
         for spec in self.current.job_specs.values():
             job = self.current.jobs[spec.name]
+            if not job.is_enabled():
+                self.current.skip.append(re.compile(spec.name))
+
             not_built = self.current.head.filter_not_built_contexts(
                 job.list_contexts(spec),
                 rebuild_failed=self.current.rebuild_failed

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -149,10 +149,6 @@ class Job(object):
             logger.debug("%s filtered.", self)
             return False
 
-        if not self.is_enabled():
-            logger.debug("%s disabled.", self)
-            return False
-
         if SETTINGS.GHP_JOBS_AUTO and self.polled_by_jenkins:
             logger.debug("%s is polled by Jenkins.", self)
             return False

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -12,13 +12,13 @@
 # You should have received a copy of the GNU General Public License along with
 # jenkins-ghp.  If not, see <http://www.gnu.org/licenses/>.
 
+from itertools import product
 import logging
 import json
 import re
 
 from jenkinsapi.build import Build
 from jenkinsapi.jenkins import Jenkins
-from jenkinsapi.custom_exceptions import UnknownJob
 from jenkins_yml import Job as JobSpec
 import requests
 
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 class LazyJenkins(object):
     build_url_re = re.compile(r'.*/job/(?P<job>.*?)/.*(?P<buildno>\d+)/?')
 
-    def __init__(self):
-        self._instance = None
+    def __init__(self, instance=None):
+        self._instance = instance
 
     def __getattr__(self, name):
         self.load()
@@ -80,18 +80,26 @@ class LazyJenkins(object):
 
     @retry
     def create_job(self, job_spec):
-        try:
-            api_instance = self._instance.get_job(job_spec.name)
-        except UnknownJob:
-            config = job_spec.as_xml()
-            if SETTINGS.GHP_DRY_RUN:
-                logger.info("Would create new Jenkins job %s.", job_spec)
-                return None
+        config = job_spec.as_xml()
+        if SETTINGS.GHP_DRY_RUN:
+            logger.info("Would create new Jenkins job %s.", job_spec)
+            return None
 
-            api_instance = self._instance.create_job(job_spec.name, config)
-            logger.warning("Created new Jenkins job %s.", job_spec.name)
-        else:
-            logger.debug("Not updating existing job %s.", job_spec.name)
+        api_instance = self._instance.create_job(job_spec.name, config)
+        logger.warning("Created new Jenkins job %s.", job_spec.name)
+
+        return Job.factory(api_instance)
+
+    @retry
+    def update_job(self, job_spec):
+        api_instance = self._instance.get_job(job_spec.name)
+        config = job_spec.as_xml()
+        if SETTINGS.GHP_DRY_RUN:
+            logger.info("Would update Jenkins job %s.", job_spec)
+            return Job.factory(api_instance)
+
+        api_instance.update_config(config)
+        logger.warning("Updated Jenkins job %s.", job_spec.name)
 
         return Job.factory(api_instance)
 
@@ -265,16 +273,35 @@ class MatrixJob(Job):
         return self._node_axis
 
     def list_contexts(self, spec):
-        if not self._instance._data['activeConfigurations']:
-            raise Exception("No active configuration for %s" % self)
+        axis = []
+        if self.node_axis:
+            if 'node' in spec.config:
+                node = spec.config['node']
+            else:
+                node = sorted(spec.config['merged_nodes'])[0]
 
-        node = None
-        if self.node_axis and 'node' in spec.config:
-            node = '%s=%s' % (self.node_axis, spec.config['node'])
+            axis.append(['%s=%s' % (self.node_axis, node)])
 
-        for c in self._instance._data['activeConfigurations']:
-            if not node or node in c['name']:
-                yield '%s/%s' % (self._instance.name, c['name'])
+        for name, values in spec.config['axis'].items():
+            axis.append(['%s=%s' % (name, v) for v in sorted(values)])
+
+        for name, values in self.spec.config['axis'].items():
+            if name in spec.config['axis']:
+                continue
+            axis.append(['%s=%s' % (name, values[0])])
+
+        combinations = [','.join(sorted(a)) for a in product(*axis)]
+        active_combinations = [
+            c['name']
+            for c in self._instance._data['activeConfigurations']
+        ]
+
+        for name in combinations:
+            if name not in active_combinations:
+                logger.warn("%s not active in Jenkins. Skipping.", name)
+                continue
+
+            yield '%s/%s' % (self._instance.name, name)
 
     def build(self, pr, spec, contexts):
         data = {'parameter': [], 'statusCode': '303', 'redirectTo': '.'}

--- a/jenkins_ghp/procedures.py
+++ b/jenkins_ghp/procedures.py
@@ -53,6 +53,7 @@ def list_repositories(with_settings=False):
     for repo in sorted(repositories.values(), key=str):
         try:
             if with_settings:
+                logger.info("Loading %s.", repo)
                 repo.load_settings()
             yield repo
         except Exception as e:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -199,6 +199,35 @@ def test_run_job_existant(GITHUB, JENKINS):
 
 @patch('jenkins_ghp.bot.JENKINS')
 @patch('jenkins_ghp.bot.GITHUB')
+def test_run_job_disabled(GITHUB, JENKINS):
+    from jenkins_ghp.bot import Bot
+
+    bot = Bot()
+    bot.extensions = {}
+
+    pr = Mock()
+
+    jenkins_job1 = Mock()
+    jenkins_job1.name = 'job1'
+    jenkins_job1.is_enabled.return_value = False
+
+    yml_job1 = Mock()
+    yml_job1.name = 'job1'
+
+    pr.commit = dict(committer=dict(date='2016-08-03T16:47:52Z'))
+    pr.repository.list_job_specs.return_value = {'job1': yml_job1}
+    pr.repository.jobs = [jenkins_job1]
+    pr.list_comments.return_value = []
+
+    bot.run(pr)
+    assert not JENKINS.create_job.mock_calls
+    assert not JENKINS.update_job.mock_calls
+    assert jenkins_job1.is_enabled.mock_calls
+    assert not jenkins_job1.contains.mock_calls
+
+
+@patch('jenkins_ghp.bot.JENKINS')
+@patch('jenkins_ghp.bot.GITHUB')
 def test_update_job(GITHUB, JENKINS):
     from jenkins_ghp.bot import Bot
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -182,6 +182,7 @@ def test_run_job_existant(GITHUB, JENKINS):
 
     jenkins_job1 = Mock()
     jenkins_job1.name = 'job1'
+    jenkins_job1.spec.contains.return_value = True
 
     yml_job1 = Mock()
     yml_job1.name = 'job1'
@@ -193,6 +194,34 @@ def test_run_job_existant(GITHUB, JENKINS):
 
     bot.run(pr)
     assert not JENKINS.create_job.mock_calls
+    assert not JENKINS.update_job.mock_calls
+
+
+@patch('jenkins_ghp.bot.JENKINS')
+@patch('jenkins_ghp.bot.GITHUB')
+def test_update_job(GITHUB, JENKINS):
+    from jenkins_ghp.bot import Bot
+
+    bot = Bot()
+    bot.extensions = {}
+
+    pr = Mock()
+
+    jenkins_job1 = Mock()
+    jenkins_job1.name = 'job1'
+    jenkins_job1.spec.contains.return_value = False
+
+    yml_job1 = Mock()
+    yml_job1.name = 'job1'
+
+    pr.commit = dict(committer=dict(date='2016-08-03T16:47:52Z'))
+    pr.repository.list_job_specs.return_value = {'job1': yml_job1}
+    pr.repository.jobs = [jenkins_job1]
+    pr.list_comments.return_value = []
+
+    bot.run(pr)
+    assert not JENKINS.create_job.mock_calls
+    assert JENKINS.update_job.mock_calls
 
 
 @patch('jenkins_ghp.bot.JENKINS')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -112,6 +112,24 @@ def test_skip_re_wrong():
     assert bot.current.head.comment.mock_calls
 
 
+def test_skip_disabled_job():
+    from jenkins_ghp.bot import Bot
+
+    bot = Bot().workon(Mock())
+    job = Mock()
+    job.is_enabled.return_value = False
+    spec = Mock()
+    spec.name = 'job-disabled'
+    bot.current.job_specs = {'job-disabled': spec}
+    bot.current.jobs = {'job-disabled': job}
+    bot.current.head.filter_not_built_contexts.return_value = ['job-disabled']
+
+    bot.extensions['builder'].run()
+
+    assert bot.extensions['builder'].skip('job-disabled')
+    assert not job.build.mock_calls
+
+
 def test_build():
     from jenkins_ghp.bot import Bot
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -112,6 +112,23 @@ def test_skip_re_wrong():
     assert bot.current.head.comment.mock_calls
 
 
+def test_build():
+    from jenkins_ghp.bot import Bot
+
+    bot = Bot().workon(Mock())
+    job = Mock()
+    spec = Mock()
+    spec.name = 'job'
+    head = bot.current.head
+    head.filter_not_built_contexts.return_value = ['job']
+
+    bot.current.job_specs = {'job': spec}
+    bot.current.jobs = {'job': job}
+    bot.current.statuses = {}
+
+    bot.extensions['builder'].run()
+
+
 def test_match_mixed():
     from jenkins_ghp.bot import Bot
 

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -76,33 +76,134 @@ def test_matrix_node_axis():
     assert 'NODE' == job.node_axis
 
 
-def test_matrix_list_context():
+def test_matrix_list_context_node():
     from jenkins_yml import Job
     from jenkins_ghp.jenkins import MatrixJob
 
     api_instance = Mock(spec=['_get_config_element_tree', 'get_params'])
     api_instance.name = 'matrix'
     api_instance._data = dict(activeConfigurations=[
-        {'name': 'P=a,NODE=slave-legacy'},
-        {'name': 'P=a,NODE=slave-ng'},
-        {'name': 'P=b,NODE=slave-legacy'},
-        {'name': 'P=b,NODE=slave-ng'},
+        {'name': 'NODE=slave-legacy,P=a'},
+        {'name': 'NODE=slave-ng,P=a'},
+        {'name': 'NODE=slave-legacy,P=b'},
+        {'name': 'NODE=slave-ng,P=b'},
     ])
 
     xml = api_instance._get_config_element_tree.return_value
     xml.findall.return_value = []
 
     job = MatrixJob(api_instance)
-
-    name_element = Mock()
-    name_element.text = 'NODE'
-    xml.findall.return_value = [name_element]
+    job._node_axis = 'NODE'
 
     spec = Job('matrix', dict(
         node='slave-ng',
+        axis={'P': ['a', 'b']},
     ))
     contexts = [c for c in job.list_contexts(spec)]
 
     assert 2 == len(contexts)
     assert 'NODE=slave-legacy' not in ''.join(contexts)
     assert 'NODE=slave-ng' in ''.join(contexts)
+
+
+def test_matrix_list_context_node_axis_only():
+    from jenkins_yml import Job
+    from jenkins_ghp.jenkins import MatrixJob
+
+    api_instance = Mock(spec=['_get_config_element_tree', 'get_params'])
+    api_instance.name = 'matrix'
+    api_instance._data = dict(activeConfigurations=[
+        {'name': 'NODE=slave,P=a'},
+        {'name': 'NODE=slave,P=b'},
+    ])
+
+    xml = api_instance._get_config_element_tree.return_value
+    xml.findall.return_value = []
+
+    job = MatrixJob(api_instance)
+    job._node_axis = 'NODE'
+
+    spec = Job('matrix', dict(
+        axis={'P': ['a', 'b']}, merged_nodes=['slave'],
+    ))
+    contexts = [c for c in job.list_contexts(spec)]
+
+    assert 2 == len(contexts)
+
+
+@patch('jenkins_ghp.jenkins.JobSpec')
+def test_matrix_list_context_superset(JobSpec):
+    from jenkins_yml import Job
+    from jenkins_ghp.jenkins import MatrixJob
+
+    api_instance = Mock(spec=['_get_config_element_tree', 'get_params'])
+    api_instance.name = 'matrix'
+    api_instance._data = dict(activeConfigurations=[
+        {'name': 'A=0,B=a'},
+        {'name': 'A=1,B=a'},
+        {'name': 'A=0,B=b'},
+        {'name': 'A=1,B=b'},
+        {'name': 'A=0,B=c'},
+        {'name': 'A=1,B=c'},
+    ])
+
+    xml = api_instance._get_config_element_tree.return_value
+    xml.findall.return_value = []
+
+    jenkins_spec = JobSpec.from_xml.return_value
+    jenkins_spec.config = dict(axis={'A': [0, 1], 'B': 'abc'})
+
+    job = MatrixJob(api_instance)
+    spec = Job('matrix', dict(axis={'B': 'acd'}))
+
+    contexts = [c for c in job.list_contexts(spec)]
+
+    haystack = '\n'.join(contexts)
+    assert 'A=0' in haystack
+    assert 'A=1' not in haystack
+    assert 'B=b' not in haystack
+    assert 2 == len(contexts)
+
+
+@patch('jenkins_ghp.jenkins.Job.factory')
+@patch('jenkins_ghp.jenkins.SETTINGS')
+def test_create_job(SETTINGS, factory):
+    from jenkins_ghp.jenkins import LazyJenkins
+
+    JENKINS = LazyJenkins(Mock())
+    spec = Mock()
+
+    SETTINGS.GHP_DRY_RUN = 1
+    JENKINS.create_job(spec)
+
+    assert not JENKINS._instance.create_job.mock_calls
+
+    SETTINGS.GHP_DRY_RUN = 0
+    JENKINS.create_job(spec)
+
+    assert JENKINS._instance.create_job.mock_calls
+    assert factory.mock_calls
+
+
+@patch('jenkins_ghp.jenkins.Job.factory')
+@patch('jenkins_ghp.jenkins.SETTINGS')
+def test_update_job(SETTINGS, factory):
+    from jenkins_ghp.jenkins import LazyJenkins
+
+    SETTINGS.GHP_DRY_RUN = 1
+
+    JENKINS = LazyJenkins(Mock())
+    spec = Mock()
+    api_instance = JENKINS._instance.get_job.return_value
+
+    JENKINS.update_job(spec)
+
+    assert not api_instance.update_config.mock_calls
+    assert factory.mock_calls
+
+    SETTINGS.GHP_DRY_RUN = 0
+
+    JENKINS.update_job(spec)
+
+    assert api_instance.update_config.mock_calls
+    assert factory.mock_calls

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch
 
 
+@patch('jenkins_ghp.procedures.Repository.load_settings')
 @patch('jenkins_ghp.procedures.SETTINGS')
 @patch('jenkins_ghp.procedures.JENKINS')
-def test_list_repositories(JENKINS, SETTINGS):
+def test_list_repositories(JENKINS, SETTINGS, load_settings):
     from jenkins_ghp import procedures
 
     JENKINS.get_jobs.return_value = []
@@ -12,7 +13,11 @@ def test_list_repositories(JENKINS, SETTINGS):
     assert 1 == len(list(repositories))
 
     SETTINGS.GHP_REPOSITORIES = "owner/repo1:master,stable owner/repo2"
-    repositories = {str(p): p for p in procedures.list_repositories()}
+    repositories = {
+        str(p): p
+        for p in procedures.list_repositories(with_settings=True)
+    }
     assert 2 == len(list(repositories))
     assert 'owner/repo1' in repositories
     assert 'owner/repo2' in repositories
+    assert load_settings.mock_calls


### PR DESCRIPTION
L'idée fondamentale est de configurer le job jenkins pour gérer les différents jenkins.yml. On se base sur `Job.merge` qui permet de définir cette *super-spec* qui inclus toute les specs.

`contains` permet de savoir si la spec du job jenkins (la *superspec*) permet d'exécuter la spec particulière de la PR. Si ce n'est pas le cas, on met à jour.