### PR TITLE
Skip non push job in builder

### DIFF
--- a/jenkins_ghp/extensions.py
+++ b/jenkins_ghp/extensions.py
@@ -99,7 +99,7 @@ jenkins: reset-skip-errors
 
         for spec in self.current.job_specs.values():
             job = self.current.jobs[spec.name]
-            if not job.is_enabled():
+            if not job.is_enabled() or not job.push_trigger:
                 self.current.skip.append(re.compile(spec.name))
 
             not_built = self.current.head.filter_not_built_contexts(

--- a/jenkins_ghp/jenkins.py
+++ b/jenkins_ghp/jenkins.py
@@ -153,12 +153,6 @@ class Job(object):
             logger.debug("%s is polled by Jenkins.", self)
             return False
 
-        # This option works only with webhook, so we can safely use it to
-        # mark a job for jenkins-ghp.
-        if SETTINGS.GHP_JOBS_AUTO and not self.push_trigger:
-            logger.debug("Trigger on push disabled on %s.", self)
-            return False
-
         return True
 
     @property


### PR DESCRIPTION
Keep periodic jobs in memory because we can build them from
jenkins.yml. This way, we don't ignore jobs we manage.