### PR TITLE
Don't trigger KeyError on del status

### DIFF
--- a/jenkins_ghp/repository.py
+++ b/jenkins_ghp/repository.py
@@ -380,7 +380,7 @@ class Head(object):
             status = CommitStatus(new_status)
             self.statuses[str(status)] = status
         else:
-            del self.statuses[status]
+            self.statuses.pop(str(status), None)
 
     @retry(wait_fixed=15000)
     def push_status(self, status):

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -111,8 +111,9 @@ job2: |
     assert 2 == len(jobs)
 
 
-def test_process_status():
-    from jenkins_ghp.repository import Head
+@patch('jenkins_ghp.repository.Head.push_status')
+def test_process_status(push_status):
+    from jenkins_ghp.repository import Head, CommitStatus
 
     head = Head(Mock(), 'master', 'd0d0', None)
     head.contexts_filter = []
@@ -127,3 +128,7 @@ def test_process_status():
     ]})
 
     assert 'job1' in head.statuses
+
+    push_status.return_value = None
+
+    head.maybe_update_status(CommitStatus(context='context'))


### PR DESCRIPTION
Fixes:

    Hit 1000 status updates on deedbeefcafe
    Failed to process https://github.com/owner/repo/pull/211 (minimal-bag8)
    Traceback (most recent call last):
    File "/usr/local/lib/python3.4/dist-packages/jenkins_ghp/main.py", line 103, in bot
        bot.run(pr)
    File "/usr/local/lib/python3.4/dist-packages/jenkins_ghp/bot.py", line 176, in run
        ext.run()
    File "/usr/local/lib/python3.4/dist-packages/jenkins_ghp/extensions.py", line 112, in run
        self.status_for_new_context(job, context),
    File "/usr/local/lib/python3.4/dist-packages/jenkins_ghp/repository.py", line 383, in maybe_update_status
        del self.statuses[status]
    KeyError: <CommitStatus pending>